### PR TITLE
Properly export MaskService

### DIFF
--- a/dist/text-input-mask.js
+++ b/dist/text-input-mask.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('react')) :
-  typeof define === 'function' && define.amd ? define(['react'], factory) :
-  (global.ReactTextMask = factory(global.react));
-}(this, (function (React) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('react')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'react'], factory) :
+  (factory((global.ReactTextMask = {}),global.react));
+}(this, (function (exports,React) { 'use strict';
 
   var React__default = 'default' in React ? React['default'] : React;
 
@@ -945,6 +945,28 @@
     return BaseTextComponent;
   }(React.Component);
 
+  var MaskService =
+  /*#__PURE__*/
+  function () {
+    function MaskService() {
+      _classCallCheck(this, MaskService);
+    }
+
+    _createClass(MaskService, null, [{
+      key: "toMask",
+      value: function toMask(type, value, settings) {
+        return MaskResolver.resolve(type).getValue(value, settings);
+      }
+    }, {
+      key: "isValid",
+      value: function isValid(type, value, settings) {
+        return MaskResolver.resolve(type).validate(value, settings);
+      }
+    }]);
+
+    return MaskService;
+  }();
+
   var TextInputMask =
   /*#__PURE__*/
   function (_BaseTextComponent) {
@@ -1032,6 +1054,9 @@
     return TextInputMask;
   }(BaseTextComponent);
 
-  return TextInputMask;
+  exports.MaskService = MaskService;
+  exports.default = TextInputMask;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
 
 })));

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
-import TextInputMask from './dist/text-input-mask';
+import TextInputMask, { MaskService } from "./dist/text-input-mask";
 
 module.exports.TextInputMask = TextInputMask;
+module.exports.MaskService = MaskService;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-masked-text",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Text and TextInput with mask for React applications, based on benhurott/react-native-masked-text.",
   "licenses": [
     {

--- a/src/text-input-mask.js
+++ b/src/text-input-mask.js
@@ -1,5 +1,8 @@
 import BaseTextComponent from './base-text-component';
 import React from 'react';
+import MaskService from "./mask-service";
+
+export { MaskService };
 
 export default class TextInputMask extends BaseTextComponent {
 


### PR DESCRIPTION
node version = v10.16.0

we need MaskService properly exported as documented in the Readme. 
Without this patch it is possible to

```
import { MaskService } from "react-masked-text/src/mask-service";
```

But this doesn't work in our test environment (which is not set up to properly run imports in `src`), so I am making this PR to export it from the top-level. 