### PR TITLE
Bugfix - macos accent

### DIFF
--- a/src/text-input-mask.tsx
+++ b/src/text-input-mask.tsx
@@ -24,7 +24,7 @@ const BaseTextComponent: ForwardRefRenderFunction<HTMLInputElement, BaseTextComp
 
     let masked = maskHandler?.getValue(defaultValue || '');
 
-    if (isControlled) {
+    if (isControlled()) {
       masked = maskHandler?.getValue(value || '') || value;
     }
 

--- a/src/text-input-mask.tsx
+++ b/src/text-input-mask.tsx
@@ -1,26 +1,17 @@
-import React, {
-  useState,
-  useEffect,
-  ForwardRefRenderFunction,
-  InputHTMLAttributes,
-} from "react";
+import React, { ForwardRefRenderFunction, InputHTMLAttributes, useEffect, useRef, useState } from 'react';
 
-import BaseMask from "./masks/base.mask";
+import BaseMask from './masks/base.mask';
 
-export interface BaseTextComponentProps
-  extends InputHTMLAttributes<HTMLInputElement> {
+export interface BaseTextComponentProps extends InputHTMLAttributes<HTMLInputElement> {
   mask?: BaseMask;
 }
 
-const BaseTextComponent: ForwardRefRenderFunction<
-  HTMLInputElement,
-  BaseTextComponentProps
-> = (props, ref) => {
+const BaseTextComponent: ForwardRefRenderFunction<HTMLInputElement, BaseTextComponentProps> = (props, ref) => {
   const { defaultValue, value, mask, type, onChange, ...otherProps } = props;
 
   const maskHandler = mask as any; // Adjust the type according to MaskResolver
 
-  const [maskedValue, setMaskedValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>();
 
   const isControlled = React.useCallback((): boolean => {
     return value !== undefined;
@@ -28,34 +19,38 @@ const BaseTextComponent: ForwardRefRenderFunction<
 
   useEffect(() => {
     if (defaultValue !== undefined && value !== undefined) {
-      throw new Error(
-        "Use either the defaultValue prop, or the value prop, but not both"
-      );
+      throw new Error('Use either the defaultValue prop, or the value prop, but not both');
     }
 
-    let masked = maskHandler?.getValue(defaultValue || "");
+    let masked = maskHandler?.getValue(defaultValue || '');
 
     if (isControlled) {
-      masked = maskHandler?.getValue(value || "") || value;
+      masked = maskHandler?.getValue(value || '') || value;
     }
 
-    setMaskedValue(masked);
+    inputRef.current.value = masked;
   }, [mask, defaultValue, value, isControlled]);
 
   const handleChangeText = async (text: string) => {
-    const maskedText = mask?.getValue(text || "") || text;
+    const maskedText = mask?.getValue(text || '') || text;
     onChange?.(maskedText as any);
 
     if (!isControlled()) {
-      setMaskedValue(maskedText);
+      inputRef.current.value = maskedText;
     }
   };
   return (
     <input
-      ref={ref}
-      type={type ?? "text"}
+      ref={(elementRef) => {
+        inputRef.current = elementRef;
+        if (typeof ref === 'function') {
+          ref(elementRef);
+        } else {
+          ref.current = elementRef;
+        }
+      }}
+      type={type ?? 'text'}
       {...otherProps}
-      value={maskedValue}
       onChange={(event) => handleChangeText(event.currentTarget.value)}
     />
   );


### PR DESCRIPTION
Usando ref.value ao invés de value={state} pois no MacOS isso estava inserindo os acentos direto ao invés de esperar pela próxima tecla